### PR TITLE
Add CLI Interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,101 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +117,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +141,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,8 +191,15 @@ checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 name = "untools"
 version = "1.0.7"
 dependencies = [
+ "clap",
  "console",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,5 @@ name = "untools"
 path = "src/lib.rs"
 
 [dependencies]
+clap = { version = "4.5.4", features = ["derive"] }
 console = "0.15.8"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In the example above:
 ------------------
 
 ## CLI Usage
-```bash
+```text
 $ untools -h
 Usage: untools [OPTIONS] <--camel-to-snake|--snake-to-camel|--batch <OUTPUT_FILE>> <INPUT>
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ use untools::camel_to_snake;
 fn main() {
     let camel_case_name = "myVariableName";
     let snake_case_name = camel_to_snake(camel_case_name, true);
-    println!("Converted name: {}", snake_case_name);
+    assert!("MY_VARIABLE_NAME', snake_case_name);
 }
 ```
 
@@ -36,8 +36,8 @@ fn main() {
 use untools::batch_convert;
 
 fn main() {
-    // Specify the input file, output file, and naming convention
-    batch_convert("input.txt", "output.txt", true);
+    // Specify the input file, output file, naming convention, and whether to operate in silent mode.
+    batch_convert("input.txt", "output.txt", true, false);
 }
 ```
 
@@ -46,7 +46,7 @@ In the example above:
 - "`input.txt`" is the path to the input file containing variable names to be converted.
 - "`output.txt`" is the path to the output file where the converted variable names will be written.
 - true indicates that the variable names will be converted to `SCREAMING_SNAKE_CASE`. Set it to false for `camelCase `conversion.
-
+- false indicates that the program will not run in silent mode.
 ------------------
 
 ## CLI Usage
@@ -62,6 +62,7 @@ Options:
       --camel-to-snake
       --snake-to-camel
       --batch <OUTPUT_FILE>
+  -s, --silent
   -h, --help                 Print help
   -V, --version              Print version
 $ untools --camel-to-snake "helloWorld" -c -s
@@ -70,7 +71,7 @@ $ untools --snake-to-camel "hello_world" -c -s
 HelloWorld
 $ untools --camel-to-snake "hello_world" -s
 helloWorld
-$ untools --batch "input.txt" "output.txt" -s
+$ untools --batch "input.txt" "output.txt" -s 
 ```
 
 ## Futures

--- a/README.md
+++ b/README.md
@@ -49,6 +49,30 @@ In the example above:
 
 ------------------
 
+## CLI Usage
+```bash
+$ untools -h
+Usage: untools [OPTIONS] <--camel-to-snake|--snake-to-camel|--batch <OUTPUT_FILE>> <INPUT>
+
+Arguments:
+  <INPUT>
+
+Options:
+  -c, --is-constant
+      --camel-to-snake
+      --snake-to-camel
+      --batch <OUTPUT_FILE>
+  -h, --help                 Print help
+  -V, --version              Print version
+$ untools --camel-to-snake "helloWorld" -c -s
+HELLO_WORLD
+$ untools --snake-to-camel "hello_world" -c -s
+HelloWorld
+$ untools --camel-to-snake "hello_world" -s
+helloWorld
+$ untools --batch "input.txt" "output.txt" -s
+```
+
 ## Futures
 
 > Here are the features and improvements we plan to add to the tool in the future. If you have any suggestions or ideas, feel free to share!

--- a/output.txt
+++ b/output.txt
@@ -1,5 +1,5 @@
-MY_VARIABLE_NAME
-ANOTHER_VARIABLE
-SOME_VARIABLE_NAME
-EXAMPLE_VARIABLE_NAME
-TEST_VARIABLE
+my_variable_name
+another_variable
+some_variable_name
+example_variable_name
+test_variable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,13 +80,13 @@ pub fn camel_to_snake(name: &str, is_constant: bool) -> String {
 /// - `ifile`: The path to the input file
 /// - `ofile`: The path to the output file
 /// - `is_constant`: Whether to convert to SCREAMING_SNAKE_CASE, `true` to convert to SCREAMING_SNAKE_CASE, `false` to convert to camelCase
-///
+/// - `silent`: Whether to supress output
 /// # Example
 ///
 /// ```rust
 /// untools::batch_convert("input.txt", "output.txt", true);
 /// ```
-pub fn batch_convert(ifile: &str, ofile: &str, is_constant: bool) {
+pub fn batch_convert(ifile: &str, ofile: &str, is_constant: bool, silent: bool) {
     let contents = fs::read_to_string(ifile).expect("Unable to read file.");
 
     let converted_names: Vec<String> = contents
@@ -96,8 +96,9 @@ pub fn batch_convert(ifile: &str, ofile: &str, is_constant: bool) {
 
     let output_content = converted_names.join("\n");
     fs::write(ofile, output_content).expect("Unable to write file.");
-
-    println!("Batch conversion successful! Results written to {}", ofile);
+    if !silent {
+        println!("Batch conversion successful! Results written to {}", ofile);
+    }
 }
 
 /// Converts a snake_case string to a camelCase string.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
 use std::fs;
 
-
-use utils::{is_camel_or_pascal_case, starts_with_digit};
 use console::style;
+use utils::{is_camel_or_pascal_case, starts_with_digit};
 
 mod utils;
 /// Converts a camelCase or PascalCase string to snake_case.
@@ -15,20 +14,31 @@ mod utils;
 /// # Arguments
 ///
 /// * `name` - A string slice that holds the variable name to be converted.
-/// * `is_constant` - A boolean flag indicating if the output should be in uppercase.
+/// * `is_constant` - A boolean flag indicating if the output should be in all caps.
 ///
 /// # Returns
 ///
 /// A String containing the snake_case version of the input variable name.
+/// 
+/// # Usage
+///
+/// This converts the the variable "testVariable" from camelcase to snakecase in all caps.
+/// 
+/// ``` 
+/// assert_eq!(camel_to_snake("testVariable", true), "TEST_VARIABLE")
+/// ```
 ///
 pub fn camel_to_snake(name: &str, is_constant: bool) -> String {
     if name.is_empty() {
-        println!("{}",style("Input string is empty. Please provide a valid variable name.").color256(208));
+        println!(
+            "{}",
+            style("Input string is empty. Please provide a valid variable name.").color256(208)
+        );
         return String::new();
     }
 
     if !starts_with_digit(name) {
-        println!("{}",style("Input string is a digit.").color256(208));
+        println!("{}", style("Input string is a digit.").color256(208));
         return String::new();
     }
 
@@ -37,7 +47,11 @@ pub fn camel_to_snake(name: &str, is_constant: bool) -> String {
     }
 
     if !is_camel_or_pascal_case(name) {
-        println!("{}",style("is not in camelCase format. Please provide a valid camelCase variable name.").color256(208));
+        println!(
+            "{}",
+            style("is not in camelCase format. Please provide a valid camelCase variable name.")
+                .color256(208)
+        );
         return String::new();
     }
 
@@ -57,26 +71,28 @@ pub fn camel_to_snake(name: &str, is_constant: bool) -> String {
     result
 }
 
-
 /// Batch convert variable names
-/// 
+///
 /// This function reads variable name data from the specified input file, converts them to the specified naming convention (camelCase or SCREAMING_SNAKE_CASE),
 /// and then writes the converted results to the specified output file.
-/// 
+///
 /// # Arguments
 /// - `ifile`: The path to the input file
 /// - `ofile`: The path to the output file
 /// - `is_constant`: Whether to convert to SCREAMING_SNAKE_CASE, `true` to convert to SCREAMING_SNAKE_CASE, `false` to convert to camelCase
-/// 
+///
 /// # Example
-/// 
+///
 /// ```rust
 /// untools::batch_convert("input.txt", "output.txt", true);
 /// ```
 pub fn batch_convert(ifile: &str, ofile: &str, is_constant: bool) {
     let contents = fs::read_to_string(ifile).expect("Unable to read file.");
 
-    let converted_names: Vec<String> = contents.lines().map(|line| camel_to_snake(line.trim(), is_constant)).collect();
+    let converted_names: Vec<String> = contents
+        .lines()
+        .map(|line| camel_to_snake(line.trim(), is_constant))
+        .collect();
 
     let output_content = converted_names.join("\n");
     fs::write(ofile, output_content).expect("Unable to write file.");
@@ -95,10 +111,12 @@ pub fn batch_convert(ifile: &str, ofile: &str, is_constant: bool) {
 ///
 /// * A String containing the camelCase representation of the input string.
 ///
-pub fn snake_to_camel(name: &str, mut to_lower_camel: bool) -> String {
+pub fn snake_to_camel(name: &str, upper_case_camel: bool) -> String {
     let mut camel_case = String::new();
     let mut capitalize_next = true;
 
+    let mut to_lower_camel = !upper_case_camel;
+    
     if name.is_empty() {
         return String::from("Input string is empty. Please provide a valid variable name.");
     }
@@ -124,6 +142,5 @@ pub fn snake_to_camel(name: &str, mut to_lower_camel: bool) -> String {
             }
         }
     }
-camel_case
+    camel_case
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,9 @@ struct Cli {
     
     #[command(flatten)]
     conversion_type: ConversionType,
+    
+    #[arg(long, short = 's')]
+    silent: bool
 }
 
 #[derive(Args, Debug, Clone)]
@@ -45,6 +48,7 @@ fn main() -> io::Result<()> {
     let input = args.input;
     
     let is_constant = args.is_constant;
+    let silent = args.silent;
     
     let conversion_type = args.conversion_type;
     let (cts, stc, b) = (conversion_type.camel_to_snake, conversion_type.snake_to_camel, conversion_type.batch);
@@ -55,12 +59,14 @@ fn main() -> io::Result<()> {
         
         (_, true, _) => { result = Some(snake_to_camel(input.as_str(), is_constant))},
         
-        (_, _, Some(output_file)) => { batch_convert(input.as_str(), output_file.as_str(), is_constant) },
+        (_, _, Some(output_file)) => { batch_convert(input.as_str(), output_file.as_str(), is_constant, silent) },
         
         _ => { unreachable!() }
     }
     
-    println!("Output");
+    if !silent {
+        println!("Output: ");
+    }
     
     if cts || stc {
         if result.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,64 @@
-
-
 //! # uutols crate
 //! A simple and user-friendly underscore variable naming tool
+use std::io;
+
 /// Main function to demonstrate the usage of the ctsc_utils crate.
 ///
 /// This function calls the `camel_to_snake_case` function from the `ctsc_utils` crate
 /// to convert the variable name "myVariableName" from camelCase to snake_case format,
 /// and then prints the result to the console.
 //mod utils;
-use untools::{camel_to_snake,batch_convert,snake_to_camel};
-fn main() {
-    println!("{}", camel_to_snake("121",true));
-    let input_file = "input.txt";
-    let output_file = "output.txt";
-    //batch_convert(input_file, output_file,true);
-    //println!("res :{}",snake_to_camel("_case_test",false));
+use untools::{camel_to_snake, snake_to_camel, batch_convert};
+
+use clap::{Parser, Args};
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+#[command(arg_required_else_help(true))]
+struct Cli {
+    input: String,
+    
+    #[arg(long, short = 'c')]
+    is_constant: bool,
+    
+    #[command(flatten)]
+    conversion_type: ConversionType,
+}
+
+#[derive(Args, Debug)]
+#[group(required = true, multiple = false)]
+struct ConversionType {
+    #[arg(long)]
+    camel_to_snake: bool,
+    
+    #[arg(long)]
+    snake_to_camel: bool,
+    
+    #[arg(long, value_name = "OUTPUT_FILE")]
+    batch: Option<String>,
+}
+
+
+fn main() -> io::Result<()> {
+    let args = Cli::parse();
+    
+    let input = args.input;
+    
+    let is_constant = args.is_constant;
+    
+    let conversion_type = args.conversion_type;
+    let (cts, stc, b) = (conversion_type.camel_to_snake, conversion_type.snake_to_camel, conversion_type.batch);
+    
+    let _result;
+    match (cts, stc, b) {
+        (true, _, _) => { _result = camel_to_snake(input.as_str(), is_constant); }
+        
+        (_, true, _) => { _result = snake_to_camel(input.as_str(), is_constant) },
+        
+        (_, _, Some(output_file)) => { batch_convert(input.as_str(), output_file.as_str(), is_constant) },
+        
+        _ => { unreachable!() }
+    }
+    
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ struct Cli {
     conversion_type: ConversionType,
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[group(required = true, multiple = false)]
 struct ConversionType {
     #[arg(long)]
@@ -49,16 +49,26 @@ fn main() -> io::Result<()> {
     let conversion_type = args.conversion_type;
     let (cts, stc, b) = (conversion_type.camel_to_snake, conversion_type.snake_to_camel, conversion_type.batch);
     
-    let _result;
+    let mut result: Option<String> = None;
     match (cts, stc, b) {
-        (true, _, _) => { _result = camel_to_snake(input.as_str(), is_constant); }
+        (true, _, _) => { result = Some(camel_to_snake(input.as_str(), is_constant)); }
         
-        (_, true, _) => { _result = snake_to_camel(input.as_str(), is_constant) },
+        (_, true, _) => { result = Some(snake_to_camel(input.as_str(), is_constant))},
         
         (_, _, Some(output_file)) => { batch_convert(input.as_str(), output_file.as_str(), is_constant) },
         
         _ => { unreachable!() }
     }
+    
+    println!("Output");
+    
+    if cts || stc {
+        if result.is_some() {
+            println!("{}", result.unwrap());
+        } 
+    }
+    
+    println!("\nCompleted!");
     
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,4 +56,3 @@ pub(crate) fn starts_with_digit(name: &str) -> bool {
     }
     true
 }
-


### PR DESCRIPTION
A simple CLI interface for use on the command line...One thing to note is that I changed the argument in `snake_to_camel` to `upper_case_camel` from `lower_case_camel`...it still does teh exact same thing because `to_lower_case_camel` is defined later down to be the opposite of `upper_case_camel`. My reason for doing that it because that means the program would only end one flag for the `is_constant` and `upper_case_camel`. If I used the `lower_case_camel`, the program would need multiple flags, one for `is_constant` and one for `lower_case_camel`. Obviously, if you have a reason you want it to be `lower_case_camel`, you can ignore this PR. Thanks for reading!